### PR TITLE
Cleanup effective C++ warnings reported by Clang and GCC

### DIFF
--- a/Dac.h
+++ b/Dac.h
@@ -76,10 +76,10 @@ class Dac
 {
 private:
     /// analog values
-    double * const dac;
+    double * const dac = nullptr;
 
     /// the dac array length
-    const unsigned int dacLength;
+    const unsigned int dacLength = 0;
 
 public:
     /**
@@ -89,6 +89,8 @@ public:
      */
     Dac(unsigned int bits);
     ~Dac();
+    Dac(const Dac&) = delete; // prevent copy
+    Dac &operator=(const Dac&) = delete; // prevent assignment
 
     /**
      * Build DAC model for specific chip.

--- a/ExternalFilter.h
+++ b/ExternalFilter.h
@@ -63,14 +63,14 @@ class ExternalFilter
 {
 private:
     /// Lowpass filter voltage
-    int Vlp;
+    int Vlp = 0;
 
     /// Highpass filter voltage
-    int Vhp;
+    int Vhp = 0;
 
-    int w0lp_1_s7;
+    int w0lp_1_s7 = 0;
 
-    int w0hp_1_s17;
+    int w0hp_1_s17 = 0;
 
 public:
     /**

--- a/Filter.h
+++ b/Filter.h
@@ -119,6 +119,10 @@ public:
 
     virtual ~Filter() {}
 
+    Filter(const Filter&) = delete; // prevent copy
+
+    Filter &operator=(const Filter&) = delete; // prevent assignment
+
     /**
      * SID clocking - 1 cycle
      *

--- a/Filter6581.h
+++ b/Filter6581.h
@@ -320,20 +320,20 @@ class Integrator;
 class Filter6581 final : public Filter
 {
 private:
-    const unsigned short* f0_dac;
+    const unsigned short* f0_dac = nullptr;
 
-    unsigned short** mixer;
-    unsigned short** summer;
-    unsigned short** gain;
+    unsigned short** mixer = {};
+    unsigned short** summer = {};
+    unsigned short** gain = {};
 
-    const int voiceScaleS14;
-    const int voiceDC;
+    const int voiceScaleS14 = 0;
+    const int voiceDC = 0;
 
     /// VCR + associated capacitor connected to highpass output.
-    std::unique_ptr<Integrator> const hpIntegrator;
+    std::unique_ptr<Integrator> const hpIntegrator = {};
 
     /// VCR + associated capacitor connected to bandpass output.
-    std::unique_ptr<Integrator> const bpIntegrator;
+    std::unique_ptr<Integrator> const bpIntegrator = {};
 
 protected:
     /**
@@ -365,6 +365,9 @@ public:
     }
 
     ~Filter6581();
+    Filter6581(const Filter6581&) = delete; // prevent copy
+    Filter6581 &operator=(const Filter6581&) = delete; // prevent assignment
+
 
     unsigned short clock(int voice1, int voice2, int voice3) override;
 

--- a/Filter8580.h
+++ b/Filter8580.h
@@ -279,21 +279,21 @@ class Integrator8580;
 class Filter8580 final : public Filter
 {
 private:
-    unsigned short** mixer;
-    unsigned short** summer;
-    unsigned short** gain_res;
-    unsigned short** gain_vol;
+    unsigned short** mixer = {};
+    unsigned short** summer = {};
+    unsigned short** gain_res = {};
+    unsigned short** gain_vol = {};
 
-    const int voiceScaleS14;
-    const int voiceDC;
+    const int voiceScaleS14 = 0;
+    const int voiceDC = 0;
 
-    double cp;
+    double cp = 0.0;
 
     /// VCR + associated capacitor connected to highpass output.
-    std::unique_ptr<Integrator8580> const hpIntegrator;
+    std::unique_ptr<Integrator8580> const hpIntegrator = {};
 
     /// VCR + associated capacitor connected to bandpass output.
-    std::unique_ptr<Integrator8580> const bpIntegrator;
+    std::unique_ptr<Integrator8580> const bpIntegrator = {};
 
 protected:
     /**
@@ -327,6 +327,8 @@ public:
     }
 
     ~Filter8580();
+    Filter8580(const Filter8580&) = delete; // prevent copy
+    Filter8580 &operator=(const Filter8580&) = delete; // prevent assignment
 
     unsigned short clock(int voice1, int voice2, int voice3) override;
 

--- a/FilterModelConfig.h
+++ b/FilterModelConfig.h
@@ -101,6 +101,8 @@ private:
 
     FilterModelConfig();
     ~FilterModelConfig();
+    FilterModelConfig(const FilterModelConfig&) = delete; // prevent copy
+    FilterModelConfig &operator=(const FilterModelConfig&) = delete; // prevent assignment
 
 public:
     static FilterModelConfig* getInstance();

--- a/FilterModelConfig8580.h
+++ b/FilterModelConfig8580.h
@@ -78,6 +78,8 @@ private:
 private:
     FilterModelConfig8580();
     ~FilterModelConfig8580();
+    FilterModelConfig8580(const FilterModelConfig8580&) = delete; // prevent copy
+    FilterModelConfig8580 &operator=(const FilterModelConfig8580&) = delete; // prevent assignment
 
 public:
     static FilterModelConfig8580* getInstance();

--- a/Integrator.h
+++ b/Integrator.h
@@ -179,6 +179,10 @@ public:
         kVddt(kVddt),
         n_snake(n_snake) {}
 
+    Integrator(const Integrator&) = delete; // prevent copy
+
+    Integrator &operator=(const Integrator&) = delete; // prevent assignment
+
     void setVw(unsigned short Vw) { Vddt_Vw_2 = ((kVddt - Vw) * (kVddt - Vw)) >> 1; }
 
     int solve(int vi) const;

--- a/Integrator8580.h
+++ b/Integrator8580.h
@@ -52,18 +52,18 @@ namespace reSIDfp
 class Integrator8580
 {
 private:
-    const unsigned short* opamp_rev;
+    const unsigned short* opamp_rev = nullptr;
 
-    mutable int vx;
-    mutable int vc;
+    mutable int vx = 0;
+    mutable int vc = 0;
 
-    unsigned short nVgt;
-    unsigned short n_dac;
+    unsigned short nVgt = 0;
+    unsigned short n_dac = 0;
 
-    const double Vth;
-    const double nKp;
-    const double vmin;
-    const double N16;
+    const double Vth = 0.0;
+    const double nKp = 0.0;
+    const double vmin = 0.0;
+    const double N16 = 0.0;
 
 public:
     Integrator8580(const unsigned short* opamp_rev, double Vth, double nKp, double vmin, double N16) :
@@ -77,6 +77,10 @@ public:
     {
         setV(1.5);
     }
+
+    Integrator8580(const Integrator8580&) = delete; // prevent copy
+
+    Integrator8580 &operator=(const Integrator8580&) = delete; // prevent assignment
 
     void setFc(double wl)
     {

--- a/SID.h
+++ b/SID.h
@@ -59,7 +59,7 @@ class SID
 {
 private:
     /// Currently active filter
-    Filter* filter;
+    Filter* filter = nullptr;
 
     /// Filter used, if model is set to 6581
     std::unique_ptr<Filter6581> const filter6581;
@@ -71,10 +71,10 @@ private:
      * External filter that provides high-pass and low-pass filtering
      * to adjust sound tone slightly.
      */
-    std::unique_ptr<ExternalFilter> const externalFilter;
+    std::unique_ptr<ExternalFilter> const externalFilter = {};
 
     /// Resampler used by audio generation code.
-    std::unique_ptr<Resampler> resampler;
+    std::unique_ptr<Resampler> resampler = {};
 
     /// Paddle X register support
     std::unique_ptr<Potentiometer> const potX;
@@ -83,25 +83,25 @@ private:
     std::unique_ptr<Potentiometer> const potY;
 
     /// SID voices
-    std::unique_ptr<Voice> voice[3];
+    std::unique_ptr<Voice> voice[3] = {};
 
     /// Time to live for the last written value
-    int busValueTtl;
+    int busValueTtl = 0;
 
     /// Current chip model's bus value TTL
-    int modelTTL;
+    int modelTTL = 0;
 
     /// Time until #voiceSync must be run.
-    unsigned int nextVoiceSync;
+    unsigned int nextVoiceSync = 0;
 
     /// Currently active chip model.
-    ChipModel model;
+    ChipModel model = MOS6581;
 
     /// Last written value
-    unsigned char busValue;
+    unsigned char busValue = 0;
 
     /// Flags for muted channels
-    bool muted[3];
+    bool muted[3] = {};
 
 private:
     /**
@@ -129,6 +129,8 @@ private:
 public:
     SID();
     ~SID();
+    SID(const SID&) = delete; // prevent copy
+    SID &operator=(const SID&) = delete; // prevent assignment
 
     /**
      * Set chip model.

--- a/Spline.h
+++ b/Spline.h
@@ -67,6 +67,10 @@ private:
 public:
     Spline(const Point input[], size_t inputLength);
 
+    Spline(const Spline&) = delete; // prevent copy
+
+    Spline &operator=(const Spline&) = delete; // prevent assignment
+
     /**
      * Evaluate y and its derivative at given point x.
      */

--- a/WaveformCalculator.cpp
+++ b/WaveformCalculator.cpp
@@ -122,8 +122,8 @@ short calculateCombinedWaveform(CombinedWaveformConfig config, int waveform, int
         distancetable[12] = 1.f;
         for (int i = 12; i > 0; i--)
         {
-            distancetable[12-i] = 1.0f / pow(config.distance1, i);
-            distancetable[12+i] = 1.0f / pow(config.distance2, i);
+            distancetable[12-i] = 1.0f / powf(config.distance1, static_cast<float>(i));
+            distancetable[12+i] = 1.0f / powf(config.distance2, static_cast<float>(i));
         }
 
         float tmp[12];

--- a/WaveformCalculator.h
+++ b/WaveformCalculator.h
@@ -95,7 +95,7 @@ private:
     typedef std::map<const CombinedWaveformConfig*, matrix_t> cw_cache_t;
 
 private:
-    cw_cache_t CACHE;
+    cw_cache_t CACHE = {};
 
     WaveformCalculator() {}
 

--- a/WaveformGenerator.cpp
+++ b/WaveformGenerator.cpp
@@ -42,7 +42,7 @@ namespace reSIDfp
  * and [VICE Bug #1128](http://sourceforge.net/p/vice-emu/bugs/1128/)
  */
 const int FLOATING_OUTPUT_TTL_6581R3 =   95000; // ~95ms
-const int FLOATING_OUTPUT_TTL_6581R4 = 1000000; // ~1s
+// const int FLOATING_OUTPUT_TTL_6581R4 = 1000000; // ~1s (unused)
 const int FLOATING_OUTPUT_TTL_8580R5 = 1000000; // ~1s
 
 /**
@@ -55,7 +55,7 @@ const int FLOATING_OUTPUT_TTL_8580R5 = 1000000; // ~1s
  * only the big difference between the old and new models.
  */
 const int SHIFT_REGISTER_RESET_6581R3 =  210000; // ~210ms
-const int SHIFT_REGISTER_RESET_6581R4 = 2150000; // ~2.15s
+// const int SHIFT_REGISTER_RESET_6581R4 = 2150000; // ~2.15s (unused)
 const int SHIFT_REGISTER_RESET_8580R5 = 2800000; // ~2.8s
 
 const int DAC_BITS = 12;

--- a/WaveformGenerator.h
+++ b/WaveformGenerator.h
@@ -84,60 +84,60 @@ namespace reSIDfp
 class WaveformGenerator
 {
 private:
-    matrix_t* model_wave;
+    matrix_t* model_wave = nullptr;
 
-    short* wave;
+    short* wave = nullptr;
 
     // PWout = (PWn/40.95)%
-    unsigned int pw;
+    unsigned int pw = 0;
 
-    unsigned int shift_register;
+    unsigned int shift_register = 0;
 
     /// Emulation of pipeline causing bit 19 to clock the shift register.
-    int shift_pipeline;
+    int shift_pipeline = 0;
 
-    unsigned int ring_msb_mask;
-    unsigned int no_noise;
-    unsigned int noise_output;
-    unsigned int no_noise_or_noise_output;
-    unsigned int no_pulse;
-    unsigned int pulse_output;
+    unsigned int ring_msb_mask = 0;
+    unsigned int no_noise = 0;
+    unsigned int noise_output = 0;
+    unsigned int no_noise_or_noise_output = 0;
+    unsigned int no_pulse = 0;
+    unsigned int pulse_output = 0;
 
     /// The control register right-shifted 4 bits; used for output function table lookup.
-    unsigned int waveform;
+    unsigned int waveform = 0;
 
-    int floating_output_ttl;
+    int floating_output_ttl = 0;
 
-    unsigned int waveform_output;
+    unsigned int waveform_output = 0;
 
     /// Current and previous accumulator value.
-    unsigned int accumulator;
+    unsigned int accumulator = 0;
 
     // Fout  = (Fn*Fclk/16777216)Hz
-    unsigned int freq;
+    unsigned int freq = 0;
 
     // 8580 tri/saw pipeline
-    unsigned int tri_saw_pipeline;
-    unsigned int osc3;
+    unsigned int tri_saw_pipeline = 0;
+    unsigned int osc3 = 0;
 
     /// Remaining time to fully reset shift register.
-    int shift_register_reset;
+    int shift_register_reset = 0;
 
     /// Current chip model's shift register reset time.
-    int model_shift_register_reset;
+    int model_shift_register_reset = 0;
 
     /// The control register bits. Gate is handled by EnvelopeGenerator.
     //@{
-    bool test;
-    bool sync;
+    bool test = false;
+    bool sync = false;
     //@}
 
     /// Tell whether the accumulator MSB was set high on this cycle.
-    bool msb_rising;
+    bool msb_rising = false;
 
-    bool is6581;
+    bool is6581 = false;
 
-    float dac[4096];
+    float dac[4096] = {};
 
 private:
     void clock_shift_register(unsigned int bit0);

--- a/array.h
+++ b/array.h
@@ -61,6 +61,8 @@ public:
 
     ~matrix() { if (count->decrease() == 0) { delete count; delete [] data; } }
 
+    matrix &operator=(const matrix&) = delete; // prevent assignment
+
     unsigned int length() const { return x * y; }
 
     T* operator[](unsigned int a) { return &data[a * y]; }

--- a/resample/SincResampler.cpp
+++ b/resample/SincResampler.cpp
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <sstream>
 
-#include "siddefs-fp.h"
+#include "../siddefs-fp.h"
 
 #ifdef HAVE_CONFIG_H
 #  include "config.h"


### PR DESCRIPTION
Addresses all of the following warnings reported when compiling with the `-Weffc++` flag.

``` text
[1/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Dac.cpp.o
In file included from ../../src/libs/residfp/Dac.cpp:23:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
[2/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Filter6581.cpp.o
In file included from ../../src/libs/residfp/Filter6581.h:30,
                 from ../../src/libs/residfp/Filter6581.cpp:25:
../../src/libs/residfp/Filter.h:32:7: warning: ‘class reSIDfp::Filter’ has pointer data members [-Weffc++]
   32 | class Filter
      |       ^~~~~~
../../src/libs/residfp/Filter.h:32:7: warning:   but does not declare ‘reSIDfp::Filter(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:32:7: warning:   or ‘operator=(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:45:21: note: pointer member ‘reSIDfp::Filter::currentResonance’ declared here
   45 |     unsigned short* currentResonance;
      |                     ^~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/FilterModelConfig.h:28,
                 from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/Filter6581.cpp:25:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
In file included from ../../src/libs/residfp/FilterModelConfig.h:29,
                 from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/Filter6581.cpp:25:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
In file included from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/Filter6581.cpp:25:
../../src/libs/residfp/FilterModelConfig.h:39:7: warning: ‘class reSIDfp::FilterModelConfig’ has pointer data members [-Weffc++]
   39 | class FilterModelConfig
      |       ^~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:84:21: note: pointer member ‘reSIDfp::FilterModelConfig::gain’ declared here
   84 |     unsigned short* gain[16];
      |                     ^~~~
In file included from ../../src/libs/residfp/Filter6581.cpp:25:
../../src/libs/residfp/Filter6581.h:320:7: warning: ‘class reSIDfp::Filter6581’ has pointer data members [-Weffc++]
  320 | class Filter6581 final : public Filter
      |       ^~~~~~~~~~
../../src/libs/residfp/Filter6581.h:320:7: warning:   but does not declare ‘reSIDfp::Filter6581(const reSIDfp::Filter6581&)’ [-Weffc++]
../../src/libs/residfp/Filter6581.h:320:7: warning:   or ‘operator=(const reSIDfp::Filter6581&)’ [-Weffc++]
../../src/libs/residfp/Filter6581.h:327:22: note: pointer member ‘reSIDfp::Filter6581::gain’ declared here
  327 |     unsigned short** gain;
      |                      ^~~~
[3/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/EnvelopeGenerator.cpp.o
In file included from ../../src/libs/residfp/EnvelopeGenerator.cpp:28:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
[4/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/ExternalFilter.cpp.o
../../src/libs/residfp/ExternalFilter.cpp: In constructor ‘reSIDfp::ExternalFilter::ExternalFilter()’:
../../src/libs/residfp/ExternalFilter.cpp:41:1: warning: ‘reSIDfp::ExternalFilter::Vlp’ should be initialized in the member initialization list [-Weffc++]
   41 | ExternalFilter::ExternalFilter() :
      | ^~~~~~~~~~~~~~
../../src/libs/residfp/ExternalFilter.cpp:41:1: warning: ‘reSIDfp::ExternalFilter::Vhp’ should be initialized in the member initialization list [-Weffc++]
[5/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Filter8580.cpp.o
In file included from ../../src/libs/residfp/Filter8580.h:30,
                 from ../../src/libs/residfp/Filter8580.cpp:25:
../../src/libs/residfp/Filter.h:32:7: warning: ‘class reSIDfp::Filter’ has pointer data members [-Weffc++]
   32 | class Filter
      |       ^~~~~~
../../src/libs/residfp/Filter.h:32:7: warning:   but does not declare ‘reSIDfp::Filter(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:32:7: warning:   or ‘operator=(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:45:21: note: pointer member ‘reSIDfp::Filter::currentResonance’ declared here
   45 |     unsigned short* currentResonance;
      |                     ^~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/FilterModelConfig8580.h:28,
                 from ../../src/libs/residfp/Filter8580.h:31,
                 from ../../src/libs/residfp/Filter8580.cpp:25:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
In file included from ../../src/libs/residfp/Filter8580.h:31,
                 from ../../src/libs/residfp/Filter8580.cpp:25:
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning: ‘class reSIDfp::FilterModelConfig8580’ has pointer data members [-Weffc++]
   38 | class FilterModelConfig8580
      |       ^~~~~~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig8580(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:72:21: note: pointer member ‘reSIDfp::FilterModelConfig8580::gain_res’ declared here
   72 |     unsigned short* gain_res[16];
      |                     ^~~~~~~~
In file included from ../../src/libs/residfp/Filter8580.h:32,
                 from ../../src/libs/residfp/Filter8580.cpp:25:
../../src/libs/residfp/Integrator8580.h: In constructor ‘reSIDfp::Integrator8580::Integrator8580(const short unsigned int*, double, double, double, double)’:
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::nVgt’ should be initialized in the member initialization list [-Weffc++]
   69 |     Integrator8580(const unsigned short* opamp_rev, double Vth, double nKp, double vmin, double N16) :
      |     ^~~~~~~~~~~~~~
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::n_dac’ should be initialized in the member initialization list [-Weffc++]
In file included from ../../src/libs/residfp/Filter8580.cpp:25:
../../src/libs/residfp/Filter8580.h: At global scope:
../../src/libs/residfp/Filter8580.h:279:7: warning: ‘class reSIDfp::Filter8580’ has pointer data members [-Weffc++]
  279 | class Filter8580 final : public Filter
      |       ^~~~~~~~~~
../../src/libs/residfp/Filter8580.h:279:7: warning:   but does not declare ‘reSIDfp::Filter8580(const reSIDfp::Filter8580&)’ [-Weffc++]
../../src/libs/residfp/Filter8580.h:279:7: warning:   or ‘operator=(const reSIDfp::Filter8580&)’ [-Weffc++]
../../src/libs/residfp/Filter8580.h:285:22: note: pointer member ‘reSIDfp::Filter8580::gain_vol’ declared here
  285 |     unsigned short** gain_vol;
      |                      ^~~~~~~~
[6/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Filter.cpp.o
In file included from ../../src/libs/residfp/Filter.cpp:23:
../../src/libs/residfp/Filter.h:32:7: warning: ‘class reSIDfp::Filter’ has pointer data members [-Weffc++]
   32 | class Filter
      |       ^~~~~~
../../src/libs/residfp/Filter.h:32:7: warning:   but does not declare ‘reSIDfp::Filter(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:32:7: warning:   or ‘operator=(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:45:21: note: pointer member ‘reSIDfp::Filter::currentResonance’ declared here
   45 |     unsigned short* currentResonance;
      |                     ^~~~~~~~~~~~~~~~
[7/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/FilterModelConfig8580.cpp.o
In file included from ../../src/libs/residfp/FilterModelConfig8580.h:28,
                 from ../../src/libs/residfp/FilterModelConfig8580.cpp:23:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
In file included from ../../src/libs/residfp/FilterModelConfig8580.cpp:23:
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning: ‘class reSIDfp::FilterModelConfig8580’ has pointer data members [-Weffc++]
   38 | class FilterModelConfig8580
      |       ^~~~~~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig8580(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:72:21: note: pointer member ‘reSIDfp::FilterModelConfig8580::gain_res’ declared here
   72 |     unsigned short* gain_res[16];
      |                     ^~~~~~~~
In file included from ../../src/libs/residfp/FilterModelConfig8580.cpp:27:
../../src/libs/residfp/Integrator8580.h: In constructor ‘reSIDfp::Integrator8580::Integrator8580(const short unsigned int*, double, double, double, double)’:
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::nVgt’ should be initialized in the member initialization list [-Weffc++]
   69 |     Integrator8580(const unsigned short* opamp_rev, double Vth, double nKp, double vmin, double N16) :
      |     ^~~~~~~~~~~~~~
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::n_dac’ should be initialized in the member initialization list [-Weffc++]
[8/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/FilterModelConfig.cpp.o
In file included from ../../src/libs/residfp/FilterModelConfig.h:28,
                 from ../../src/libs/residfp/FilterModelConfig.cpp:23:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
In file included from ../../src/libs/residfp/FilterModelConfig.h:29,
                 from ../../src/libs/residfp/FilterModelConfig.cpp:23:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
In file included from ../../src/libs/residfp/FilterModelConfig.cpp:23:
../../src/libs/residfp/FilterModelConfig.h:39:7: warning: ‘class reSIDfp::FilterModelConfig’ has pointer data members [-Weffc++]
   39 | class FilterModelConfig
      |       ^~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:84:21: note: pointer member ‘reSIDfp::FilterModelConfig::gain’ declared here
   84 |     unsigned short* gain[16];
      |                     ^~~~
[9/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Integrator8580.cpp.o
In file included from ../../src/libs/residfp/Integrator8580.cpp:23:
../../src/libs/residfp/Integrator8580.h: In constructor ‘reSIDfp::Integrator8580::Integrator8580(const short unsigned int*, double, double, double, double)’:
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::nVgt’ should be initialized in the member initialization list [-Weffc++]
   69 |     Integrator8580(const unsigned short* opamp_rev, double Vth, double nKp, double vmin, double N16) :
      |     ^~~~~~~~~~~~~~
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::n_dac’ should be initialized in the member initialization list [-Weffc++]
[11/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/OpAmp.cpp.o
In file included from ../../src/libs/residfp/OpAmp.h:28,
                 from ../../src/libs/residfp/OpAmp.cpp:22:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
[12/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/resample_SincResampler.cpp.o
In file included from ../../src/libs/residfp/resample/SincResampler.cpp:23:
../../src/libs/residfp/resample/SincResampler.h:51:7: warning: ‘class reSIDfp::SincResampler’ has pointer data members [-Weffc++]
   51 | class SincResampler final : public Resampler
      |       ^~~~~~~~~~~~~
../../src/libs/residfp/resample/SincResampler.h:51:7: warning:   but does not declare ‘reSIDfp::SincResampler(const reSIDfp::SincResampler&)’ [-Weffc++]
../../src/libs/residfp/resample/SincResampler.h:51:7: warning:   or ‘operator=(const reSIDfp::SincResampler&)’ [-Weffc++]
../../src/libs/residfp/resample/SincResampler.h:59:15: note: pointer member ‘reSIDfp::SincResampler::firTable’ declared here
   59 |     matrix_t* firTable;
      |               ^~~~~~~~
In file included from ../../src/libs/residfp/resample/SincResampler.h:31,
                 from ../../src/libs/residfp/resample/SincResampler.cpp:23:
../../src/libs/residfp/resample/../array.h: In instantiation of ‘class matrix<short int>’:
../../src/libs/residfp/resample/SincResampler.cpp:129:76:   required from here
../../src/libs/residfp/resample/../array.h:42:7: warning: ‘class matrix<short int>’ has pointer data members [-Weffc++]
   42 | class matrix
      |       ^~~~~~
../../src/libs/residfp/resample/../array.h:42:7: warning:   but does not declare ‘operator=(const matrix<short int>&)’ [-Weffc++]
../../src/libs/residfp/resample/../array.h:46:14: note: pointer member ‘matrix<short int>::count’ declared here
   46 |     counter* count;
      |              ^~~~~
../../src/libs/residfp/resample/SincResampler.cpp: In constructor ‘reSIDfp::SincResampler::SincResampler(double, double, double)’:
../../src/libs/residfp/resample/SincResampler.cpp:146:1: warning: ‘reSIDfp::SincResampler::firTable’ should be initialized in the member initialization list [-Weffc++]
  146 | SincResampler::SincResampler(double clockFrequency, double samplingFrequency, double highestAccurateFrequency) :
      | ^~~~~~~~~~~~~
../../src/libs/residfp/resample/SincResampler.cpp:146:1: warning: ‘reSIDfp::SincResampler::firRES’ should be initialized in the member initialization list [-Weffc++]
../../src/libs/residfp/resample/SincResampler.cpp:146:1: warning: ‘reSIDfp::SincResampler::firN’ should be initialized in the member initialization list [-Weffc++]
[13/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/SID.cpp.o
In file included from ../../src/libs/residfp/SID.cpp:25:
../../src/libs/residfp/SID.h:58:7: warning: ‘class reSIDfp::SID’ has pointer data members [-Weffc++]
   58 | class SID
      |       ^~~
../../src/libs/residfp/SID.h:58:7: warning:   but does not declare ‘reSIDfp::SID(const reSIDfp::SID&)’ [-Weffc++]
../../src/libs/residfp/SID.h:58:7: warning:   or ‘operator=(const reSIDfp::SID&)’ [-Weffc++]
../../src/libs/residfp/SID.h:62:13: note: pointer member ‘reSIDfp::SID::filter’ declared here
   62 |     Filter* filter;
      |             ^~~~~~
In file included from ../../src/libs/residfp/SID.h:275,
                 from ../../src/libs/residfp/SID.cpp:25:
../../src/libs/residfp/Filter.h:32:7: warning: ‘class reSIDfp::Filter’ has pointer data members [-Weffc++]
   32 | class Filter
      |       ^~~~~~
../../src/libs/residfp/Filter.h:32:7: warning:   but does not declare ‘reSIDfp::Filter(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:32:7: warning:   or ‘operator=(const reSIDfp::Filter&)’ [-Weffc++]
../../src/libs/residfp/Filter.h:45:21: note: pointer member ‘reSIDfp::Filter::currentResonance’ declared here
   45 |     unsigned short* currentResonance;
      |                     ^~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/Voice.h:29,
                 from ../../src/libs/residfp/SID.h:277,
                 from ../../src/libs/residfp/SID.cpp:25:
../../src/libs/residfp/WaveformGenerator.h: In constructor ‘reSIDfp::WaveformGenerator::WaveformGenerator()’:
../../src/libs/residfp/WaveformGenerator.h:183:5: warning: ‘reSIDfp::WaveformGenerator::model_shift_register_reset’ should be initialized in the member initialization list [-Weffc++]
  183 |     WaveformGenerator() :
      |     ^~~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/FilterModelConfig.h:28,
                 from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/SID.cpp:30:
../../src/libs/residfp/Dac.h: At global scope:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
In file included from ../../src/libs/residfp/FilterModelConfig.h:29,
                 from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/SID.cpp:30:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
In file included from ../../src/libs/residfp/Filter6581.h:31,
                 from ../../src/libs/residfp/SID.cpp:30:
../../src/libs/residfp/FilterModelConfig.h:39:7: warning: ‘class reSIDfp::FilterModelConfig’ has pointer data members [-Weffc++]
   39 | class FilterModelConfig
      |       ^~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:39:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig.h:84:21: note: pointer member ‘reSIDfp::FilterModelConfig::gain’ declared here
   84 |     unsigned short* gain[16];
      |                     ^~~~
In file included from ../../src/libs/residfp/SID.cpp:30:
../../src/libs/residfp/Filter6581.h:320:7: warning: ‘class reSIDfp::Filter6581’ has pointer data members [-Weffc++]
  320 | class Filter6581 final : public Filter
      |       ^~~~~~~~~~
../../src/libs/residfp/Filter6581.h:320:7: warning:   but does not declare ‘reSIDfp::Filter6581(const reSIDfp::Filter6581&)’ [-Weffc++]
../../src/libs/residfp/Filter6581.h:320:7: warning:   or ‘operator=(const reSIDfp::Filter6581&)’ [-Weffc++]
../../src/libs/residfp/Filter6581.h:327:22: note: pointer member ‘reSIDfp::Filter6581::gain’ declared here
  327 |     unsigned short** gain;
      |                      ^~~~
In file included from ../../src/libs/residfp/Filter8580.h:31,
                 from ../../src/libs/residfp/SID.cpp:31:
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning: ‘class reSIDfp::FilterModelConfig8580’ has pointer data members [-Weffc++]
   38 | class FilterModelConfig8580
      |       ^~~~~~~~~~~~~~~~~~~~~
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   but does not declare ‘reSIDfp::FilterModelConfig8580(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:38:7: warning:   or ‘operator=(const reSIDfp::FilterModelConfig8580&)’ [-Weffc++]
../../src/libs/residfp/FilterModelConfig8580.h:72:21: note: pointer member ‘reSIDfp::FilterModelConfig8580::gain_res’ declared here
   72 |     unsigned short* gain_res[16];
      |                     ^~~~~~~~
In file included from ../../src/libs/residfp/Filter8580.h:32,
                 from ../../src/libs/residfp/SID.cpp:31:
../../src/libs/residfp/Integrator8580.h: In constructor ‘reSIDfp::Integrator8580::Integrator8580(const short unsigned int*, double, double, double, double)’:
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::nVgt’ should be initialized in the member initialization list [-Weffc++]
   69 |     Integrator8580(const unsigned short* opamp_rev, double Vth, double nKp, double vmin, double N16) :
      |     ^~~~~~~~~~~~~~
../../src/libs/residfp/Integrator8580.h:69:5: warning: ‘reSIDfp::Integrator8580::n_dac’ should be initialized in the member initialization list [-Weffc++]
In file included from ../../src/libs/residfp/SID.cpp:31:
../../src/libs/residfp/Filter8580.h: At global scope:
../../src/libs/residfp/Filter8580.h:279:7: warning: ‘class reSIDfp::Filter8580’ has pointer data members [-Weffc++]
  279 | class Filter8580 final : public Filter
      |       ^~~~~~~~~~
../../src/libs/residfp/Filter8580.h:279:7: warning:   but does not declare ‘reSIDfp::Filter8580(const reSIDfp::Filter8580&)’ [-Weffc++]
../../src/libs/residfp/Filter8580.h:279:7: warning:   or ‘operator=(const reSIDfp::Filter8580&)’ [-Weffc++]
../../src/libs/residfp/Filter8580.h:285:22: note: pointer member ‘reSIDfp::Filter8580::gain_vol’ declared here
  285 |     unsigned short** gain_vol;
      |                      ^~~~~~~~
In file included from ../../src/libs/residfp/SID.cpp:33:
../../src/libs/residfp/WaveformCalculator.h: In constructor ‘reSIDfp::WaveformCalculator::WaveformCalculator()’:
../../src/libs/residfp/WaveformCalculator.h:100:5: warning: ‘reSIDfp::WaveformCalculator::CACHE’ should be initialized in the member initialization list [-Weffc++]
  100 |     WaveformCalculator() {}
      |     ^~~~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/resample/TwoPassSincResampler.h:30,
                 from ../../src/libs/residfp/SID.cpp:34:
../../src/libs/residfp/resample/SincResampler.h: At global scope:
../../src/libs/residfp/resample/SincResampler.h:51:7: warning: ‘class reSIDfp::SincResampler’ has pointer data members [-Weffc++]
   51 | class SincResampler final : public Resampler
      |       ^~~~~~~~~~~~~
../../src/libs/residfp/resample/SincResampler.h:51:7: warning:   but does not declare ‘reSIDfp::SincResampler(const reSIDfp::SincResampler&)’ [-Weffc++]
../../src/libs/residfp/resample/SincResampler.h:51:7: warning:   or ‘operator=(const reSIDfp::SincResampler&)’ [-Weffc++]
../../src/libs/residfp/resample/SincResampler.h:59:15: note: pointer member ‘reSIDfp::SincResampler::firTable’ declared here
   59 |     matrix_t* firTable;
      |               ^~~~~~~~
../../src/libs/residfp/SID.cpp: In constructor ‘reSIDfp::SID::SID()’:
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::filter’ should be initialized in the member initialization list [-Weffc++]
   62 | SID::SID() :
      | ^~~
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::busValueTtl’ should be initialized in the member initialization list [-Weffc++]
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::modelTTL’ should be initialized in the member initialization list [-Weffc++]
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::nextVoiceSync’ should be initialized in the member initialization list [-Weffc++]
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::model’ should be initialized in the member initialization list [-Weffc++]
../../src/libs/residfp/SID.cpp:62:1: warning: ‘reSIDfp::SID::busValue’ should be initialized in the member initialization list [-Weffc++]
In file included from ../../src/libs/residfp/WaveformGenerator.h:27,
                 from ../../src/libs/residfp/Voice.h:29,
                 from ../../src/libs/residfp/SID.h:277,
                 from ../../src/libs/residfp/SID.cpp:25:
../../src/libs/residfp/array.h: In instantiation of ‘class matrix<short int>’:
/usr/include/c++/10/bits/stl_pair.h:218:11:   required from ‘struct std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> >’
/usr/include/c++/10/ext/aligned_buffer.h:56:65:   required from ‘struct __gnu_cxx::__aligned_membuf<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >’
/usr/include/c++/10/bits/stl_tree.h:231:41:   required from ‘struct std::_Rb_tree_node<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >’
/usr/include/c++/10/bits/stl_tree.h:1919:21:   required from ‘void std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_erase(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Link_type) [with _Key = const reSIDfp::CombinedWaveformConfig*; _Val = std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> >; _KeyOfValue = std::_Select1st<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >; _Compare = std::less<const reSIDfp::CombinedWaveformConfig*>; _Alloc = std::allocator<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Link_type = std::_Rb_tree_node<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >*]’
/usr/include/c++/10/bits/stl_tree.h:991:9:   required from ‘std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::~_Rb_tree() [with _Key = const reSIDfp::CombinedWaveformConfig*; _Val = std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> >; _KeyOfValue = std::_Select1st<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >; _Compare = std::less<const reSIDfp::CombinedWaveformConfig*>; _Alloc = std::allocator<std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> > >]’
/usr/include/c++/10/bits/stl_map.h:185:7:   required from here
../../src/libs/residfp/array.h:42:7: warning: ‘class matrix<short int>’ has pointer data members [-Weffc++]
   42 | class matrix
      |       ^~~~~~
../../src/libs/residfp/array.h:42:7: warning:   but does not declare ‘operator=(const matrix<short int>&)’ [-Weffc++]
../../src/libs/residfp/array.h:46:14: note: pointer member ‘matrix<short int>::count’ declared here
   46 |     counter* count;
      |              ^~~~~
[14/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/Spline.cpp.o
In file included from ../../src/libs/residfp/Spline.cpp:22:
../../src/libs/residfp/Spline.h:38:7: warning: ‘class reSIDfp::Spline’ has pointer data members [-Weffc++]
   38 | class Spline
      |       ^~~~~~
../../src/libs/residfp/Spline.h:38:7: warning:   but does not declare ‘reSIDfp::Spline(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:38:7: warning:   or ‘operator=(const reSIDfp::Spline&)’ [-Weffc++]
../../src/libs/residfp/Spline.h:65:40: note: pointer member ‘reSIDfp::Spline::c’ declared here
   65 |     mutable ParamVector::const_pointer c;
      |                                        ^
[15/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/WaveformCalculator.cpp.o
In file included from ../../src/libs/residfp/WaveformCalculator.cpp:22:
../../src/libs/residfp/WaveformCalculator.h: In constructor ‘reSIDfp::WaveformCalculator::WaveformCalculator()’:
../../src/libs/residfp/WaveformCalculator.h:100:5: warning: ‘reSIDfp::WaveformCalculator::CACHE’ should be initialized in the member initialization list [-Weffc++]
  100 |     WaveformCalculator() {}
      |     ^~~~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/WaveformCalculator.h:28,
                 from ../../src/libs/residfp/WaveformCalculator.cpp:22:
../../src/libs/residfp/array.h: In instantiation of ‘class matrix<short int>’:
/usr/include/c++/10/bits/stl_pair.h:218:11:   required from ‘struct std::pair<const reSIDfp::CombinedWaveformConfig* const, matrix<short int> >’
../../src/libs/residfp/WaveformCalculator.cpp:179:25:   required from here
../../src/libs/residfp/array.h:42:7: warning: ‘class matrix<short int>’ has pointer data members [-Weffc++]
   42 | class matrix
      |       ^~~~~~
../../src/libs/residfp/array.h:42:7: warning:   but does not declare ‘operator=(const matrix<short int>&)’ [-Weffc++]
../../src/libs/residfp/array.h:46:14: note: pointer member ‘matrix<short int>::count’ declared here
   46 |     counter* count;
      |              ^~~~~
[16/22] Compiling C++ object src/hardware/libhardware.a.p/innovation.cpp.o
In file included from ../../src/hardware/innovation.h:36,
                 from ../../src/hardware/innovation.cpp:20:
../../src/hardware/../libs/residfp/SID.h:58:7: warning: ‘class reSIDfp::SID’ has pointer data members [-Weffc++]
   58 | class SID
      |       ^~~
../../src/hardware/../libs/residfp/SID.h:58:7: warning:   but does not declare ‘reSIDfp::SID(const reSIDfp::SID&)’ [-Weffc++]
../../src/hardware/../libs/residfp/SID.h:58:7: warning:   or ‘operator=(const reSIDfp::SID&)’ [-Weffc++]
../../src/hardware/../libs/residfp/SID.h:62:13: note: pointer member ‘reSIDfp::SID::filter’ declared here
   62 |     Filter* filter;
      |             ^~~~~~
In file included from ../../src/hardware/../libs/residfp/SID.h:275,
                 from ../../src/hardware/innovation.h:36,
                 from ../../src/hardware/innovation.cpp:20:
../../src/hardware/../libs/residfp/Filter.h:32:7: warning: ‘class reSIDfp::Filter’ has pointer data members [-Weffc++]
   32 | class Filter
      |       ^~~~~~
../../src/hardware/../libs/residfp/Filter.h:32:7: warning:   but does not declare ‘reSIDfp::Filter(const reSIDfp::Filter&)’ [-Weffc++]
../../src/hardware/../libs/residfp/Filter.h:32:7: warning:   or ‘operator=(const reSIDfp::Filter&)’ [-Weffc++]
../../src/hardware/../libs/residfp/Filter.h:45:21: note: pointer member ‘reSIDfp::Filter::currentResonance’ declared here
   45 |     unsigned short* currentResonance;
      |                     ^~~~~~~~~~~~~~~~
In file included from ../../src/hardware/../libs/residfp/Voice.h:29,
                 from ../../src/hardware/../libs/residfp/SID.h:277,
                 from ../../src/hardware/innovation.h:36,
                 from ../../src/hardware/innovation.cpp:20:
../../src/hardware/../libs/residfp/WaveformGenerator.h: In constructor ‘reSIDfp::WaveformGenerator::WaveformGenerator()’:
../../src/hardware/../libs/residfp/WaveformGenerator.h:183:5: warning: ‘reSIDfp::WaveformGenerator::model_shift_register_reset’ should be initialized in the member initialization list [-Weffc++]
  183 |     WaveformGenerator() :
      |     ^~~~~~~~~~~~~~~~~
[17/22] Compiling C++ object src/libs/residfp/libresidfp.a.p/WaveformGenerator.cpp.o
In file included from ../../src/libs/residfp/WaveformGenerator.cpp:25:
../../src/libs/residfp/WaveformGenerator.h: In constructor ‘reSIDfp::WaveformGenerator::WaveformGenerator()’:
../../src/libs/residfp/WaveformGenerator.h:183:5: warning: ‘reSIDfp::WaveformGenerator::model_shift_register_reset’ should be initialized in the member initialization list [-Weffc++]
  183 |     WaveformGenerator() :
      |     ^~~~~~~~~~~~~~~~~
In file included from ../../src/libs/residfp/WaveformGenerator.cpp:27:
../../src/libs/residfp/Dac.h: At global scope:
../../src/libs/residfp/Dac.h:75:7: warning: ‘class reSIDfp::Dac’ has pointer data members [-Weffc++]
   75 | class Dac
      |       ^~~
../../src/libs/residfp/Dac.h:75:7: warning:   but does not declare ‘reSIDfp::Dac(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:75:7: warning:   or ‘operator=(const reSIDfp::Dac&)’ [-Weffc++]
../../src/libs/residfp/Dac.h:79:20: note: pointer member ‘reSIDfp::Dac::dac’ declared here
   79 |     double * const dac;
      |                    ^~~
In file included from ../../src/libs/residfp/WaveformGenerator.h:27,
                 from ../../src/libs/residfp/WaveformGenerator.cpp:25:
../../src/libs/residfp/array.h: In instantiation of ‘class matrix<short int>’:
../../src/libs/residfp/WaveformGenerator.cpp:219:44:   required from here
../../src/libs/residfp/array.h:42:7: warning: ‘class matrix<short int>’ has pointer data members [-Weffc++]
   42 | class matrix
      |       ^~~~~~
../../src/libs/residfp/array.h:42:7: warning:   but does not declare ‘operator=(const matrix<short int>&)’ [-Weffc++]
../../src/libs/residfp/array.h:46:14: note: pointer member ‘matrix<short int>::count’ declared here
   46 |     counter* count;
      |              ^~~~~
```